### PR TITLE
Add rubocop lint step to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Ruby
 on: [push,pull_request]
 
 jobs:
-  build:
+  ruby:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -14,6 +14,8 @@ jobs:
         bundler-cache: true
     - name: Run the default task
       run: bundle exec rake
+    - name: Lint
+      run: bundle exec rubocop
   kind:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Just some housekeeping to add Rubocop linter to github actions so we can deal with lint issues before merging