### PR TITLE
Run integration tests in parallel

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,8 @@ end
 
 desc("Run in-cluster integrations tests")
 Rake::TestTask.new(:test_integration) do |task|
+  ENV["PARALLELIZE_ME"] = ENV.fetch("PARALLELIZE_ME", "1")
+  ENV["MT_CPU"] = ENV.fetch("MT_CPU", "8")
   task.libs << "test"
   task.libs << "lib"
   task.test_files = FileList["test/integration/**/*_test.rb"]

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -11,6 +11,11 @@ module KubeclientNext
     MissingContextError = Class.new(Error)
     KubectlError = Class.new(Error)
 
+    if ENV["PARALLELIZE_ME"]
+      puts "Running tests in parallel! (# Threads: #{ENV["MT_CPU"]}"
+      parallelize_me!
+    end
+
     def run
       super do
         @config = kubeconfig


### PR DESCRIPTION
Closes #21

Integration tests are slow (scaffolding and cleaning up k8s namespaces), let's speed them up by running tests in parallel.